### PR TITLE
fixed bug on windows and added an example 

### DIFF
--- a/lib/rc/sign.js
+++ b/lib/rc/sign.js
@@ -17,7 +17,8 @@
         return result = result + data.toString('utf8');
       });
       proc.stdout.on('end', function(end){
-        return resolve(result.split("\n\n")[1]);
+        // changed \n\n to /\r?\n\r?\n/gm because on windows next line sometimes is \r\n instead of \n
+        return resolve(result.split(/\r?\n\r?\n/gm)[1]);
       });
       errorData = "";
       proc.stderr.on('data', function(data){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eghtesad-novin-checkout",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eghtesad-novin-checkout",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Unofficial NodeJS implementation of Novin Pardakht Eghtesad Novin Gateway API",
   "main": "./lib/rc/index.js",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Here is an example of client side.
  <body>
   <script>
    var f = document.createElement('form');
-   f.action='https://pna.shaparak.ir/_ipgw_/payment/';
+   f.action='https://pna.shaparak.ir/_ipgw_/payment/';      // back endpoint 
    f.method='POST';
 
    var i=document.createElement('input');

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,35 @@ eghtesadNovin.requestPaymentToken(
 });
 ```
 
+#### Client side:
+Here is an example of client side.
+```html
+<html>
+ <body>
+  <script>
+   var f = document.createElement('form');
+   f.action='https://pna.shaparak.ir/_ipgw_/payment/';
+   f.method='POST';
+
+   var i=document.createElement('input');
+   i.type='hidden';
+   i.name='token';
+   i.value='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';		// your bank token
+   f.appendChild(i);
+
+   var j=document.createElement('input');
+   j.type='hidden';
+   j.name='language';
+   j.value='fa';
+   f.appendChild(j);
+
+   document.body.appendChild(f);
+   f.submit();
+  </script>
+ </body>
+</html>
+```
+
 After making Post request to bank URL, user will follow bank instructions then he will posted to your callbackUrl, make sure that your endpoint should accept Post method.  
 These parameters will be accesible via bank Post request in endpoint:
   - State // if payment is successfull they will send "ok" string (do toLowerCase to avoid furture problems)

--- a/src/sign.ls
+++ b/src/sign.ls
@@ -30,7 +30,7 @@ module.exports = (dataToSign, pemKeyAddress) ->
     result := result + data.toString('utf8')
 
   proc.stdout.on 'end', (end) ->
-    resolve result.split("\n\n")[1]
+    resolve result.split(/\r?\n\r?\n/gm)[1]
 
   errorData = ""
   proc.stderr.on 'data', (data) ->


### PR DESCRIPTION
Hi 
There was a bug when using package on windows.
Apparently \r\n in windows is equal to \n and sometimes is used instead of \n therefore when you split bank signature by \n\n and select second part it does not work correctly I tried to fix it using a regex (/\r?\n \r?\n/gm) now it works correctly on windows too.

Also I added an example for client side because flow was very confusing to me and I thought an example could help a lot.

Thank you for this awesome package.